### PR TITLE
PR1 fixes / improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Ricecooker dirs
+storage
+.ricecookerfilecache
+restore
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 storage
 .ricecookerfilecache
 restore
+chefdata/youtubecache
 
 
 # Byte-compiled / optimized / DLL files

--- a/arvind.py
+++ b/arvind.py
@@ -81,7 +81,7 @@ class ArvindVideo():
         self.url = url
         self.title = title
         self.description = description
-        self.thumbnail = ''
+        self.thumbnail = None
         self.filepath = ''
         self.language = language
         self.filename_prefix = filename_prefix
@@ -104,7 +104,7 @@ class ArvindVideo():
         self.filepath = filename % video_info
 
         for thumbnail in video_info.get('thumbnails', None):
-            value = thumbnail.get('filename', '')
+            value = thumbnail.get('url')
 
             if value:
                 self.thumbnail = value
@@ -112,8 +112,8 @@ class ArvindVideo():
 
         return self.filepath
 
-    def download(self, download_dir="./"):
-        print('====> download()', self.get_filename(download_dir))
+    def download_info(self, download_dir="./", download=False):
+        print('====> download_info()', self.get_filename(download_dir))
         ydl_options = {
             'outtmpl': self.get_filename(download_dir),
             'writethumbnail': True,
@@ -129,19 +129,19 @@ class ArvindVideo():
             try:
                 ydl.add_default_info_extractors()
                 # vinfo = ydl.extract_info(self.url, download=True)
-                vinfo = ydl.extract_info(self.url, download=True)
+                vinfo = ydl.extract_info(self.url, download=download)
                 # Save the remaining "temporary scraped values" of attributes with actual values
                 # from the video metadata.
-                self.uid = vinfo.get('id', '')
-                self.title = vinfo.get('title', '')                             
-                self.description = vinfo.get('description', '')                             
+                self.uid = vinfo['id']  # video must have id because required to set youtube_id later
+                self.title = vinfo.get('title', '')
+                self.description = vinfo.get('description', '')
 
                 # Set the filepath and thumbnail attributes of the video object.
                 self.filepath = self.set_filepath_and_thumbnail(vinfo, download_dir=download_dir)
                 
                 if not vinfo['license']:
                     self.license = "Licensed not available"
-                elif vinfo['license'].find("Creative Commons") != -1:
+                elif "Creative Commons" in vinfo['license']:
                     self.license_common = True
                 else:
                     self.license = vinfo['license']

--- a/arvind.py
+++ b/arvind.py
@@ -1,20 +1,26 @@
+import json
+import os
 import pprint
+import re
 import youtube_dl
 
 from le_utils.constants.languages import getlang_by_name
 
+
+YOUTUBE_CACHE_DIR = os.path.join('chefdata', 'youtubecache')
+YOUTUBE_ID_REGEX = re.compile(r'(https?://)?(www\.)?(youtube|youtu|youtube-nocookie)\.(com|be)/(watch\?v=|embed/|v/|.+\?v=)?(?P<youtube_id>[A-Za-z0-9\-=_]{11})')
 
 # List of languages not avialble at the le_utils
 UND_LANG = {
             "marwari":{
                 "name":"Marwari",
                 "native_name":"marwari",
-                "code": "mwr",
+                "code": "und",      # temporary while le-utils updated in Studio
             },
             "bhojpuri":{
                 "name":"Bhojpuri",
                 "native_name":"bhojpuri",
-                "code":"bho",
+                "code":"und",       # temporary while le-utils updated in Studio
             },
             "odiya":{
                 "name":"Odiya",
@@ -59,6 +65,7 @@ class ArvindLanguage():
                 self.set_value(language_obj.name, language_obj.code, language_obj.native_name)
                 return True
         return False
+
 
 
 class ArvindVideo():
@@ -124,32 +131,49 @@ class ArvindVideo():
             # Note the format specification is important so we get mp4 and not taller than 480
             'format': "bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[height<=480][ext=mp4]"
         }
-        with youtube_dl.YoutubeDL(ydl_options) as ydl:
-            pp = pprint.PrettyPrinter()
-            try:
-                ydl.add_default_info_extractors()
-                # vinfo = ydl.extract_info(self.url, download=True)
-                vinfo = ydl.extract_info(self.url, download=download)
-                # Save the remaining "temporary scraped values" of attributes with actual values
-                # from the video metadata.
-                self.uid = vinfo['id']  # video must have id because required to set youtube_id later
-                self.title = vinfo.get('title', '')
-                self.description = vinfo.get('description', '')
 
-                # Set the filepath and thumbnail attributes of the video object.
-                self.filepath = self.set_filepath_and_thumbnail(vinfo, download_dir=download_dir)
-                
-                if not vinfo['license']:
-                    self.license = "Licensed not available"
-                elif "Creative Commons" in vinfo['license']:
-                    self.license_common = True
-                else:
-                    self.license = vinfo['license']
+        match = YOUTUBE_ID_REGEX.match(self.url)
+        if not match:
+            print('==> URL ' + self.url + ' does not match YOUTUBE_ID_REGEX')
+            return False
+        youtube_id = match.group('youtube_id')
 
-            except (youtube_dl.utils.DownloadError,
-                    youtube_dl.utils.ContentTooShortError,
-                    youtube_dl.utils.ExtractorError,) as e:
-                    print('==> Error downloading videos', e)
-                    # pp.pprint(e)
-                    return False
+        vinfo_json_path = os.path.join(YOUTUBE_CACHE_DIR, youtube_id+'.json')
+        # First try to get from cache:
+        if os.path.exists(vinfo_json_path):
+            vinfo = json.load(open(vinfo_json_path))
+
+        # else get using youtube_dl:
+        else:
+            with youtube_dl.YoutubeDL(ydl_options) as ydl:
+                pp = pprint.PrettyPrinter()
+                try:
+                    ydl.add_default_info_extractors()
+                    # vinfo = ydl.extract_info(self.url, download=True)
+                    vinfo = ydl.extract_info(self.url, download=download)
+                    # Save the remaining "temporary scraped values" of attributes with actual values
+                    # from the video metadata.
+                    json.dump(vinfo, open(vinfo_json_path, 'w'), indent=4, ensure_ascii=False, sort_keys=True)
+
+                except (youtube_dl.utils.DownloadError,
+                        youtube_dl.utils.ContentTooShortError,
+                        youtube_dl.utils.ExtractorError,) as e:
+                        print('==> Error downloading videos', e)
+                        # pp.pprint(e)
+                        return False
+
+        self.uid = vinfo['id']  # video must have id because required to set youtube_id later
+        self.title = vinfo.get('title', '')
+        self.description = vinfo.get('description', '')
+
+        # Set the filepath and thumbnail attributes of the video object.
+        self.filepath = self.set_filepath_and_thumbnail(vinfo, download_dir=download_dir)
+
+        if not vinfo['license']:
+            self.license = "Licensed not available"
+        elif "Creative Commons" in vinfo['license']:
+            self.license_common = True
+        else:
+            self.license = vinfo['license']
+
         return True

--- a/requirments-dev.txt
+++ b/requirments-dev.txt
@@ -1,6 +1,0 @@
-beautifulsoup4==4.8.0
-le-utils==0.1.20
-requests==2.22.0
-ricecooker==0.6.35
-youtube-dl==2019.9.12.1
-

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,0 +1,5 @@
+beautifulsoup4>=4.8.0
+le-utils==0.1.19
+requests>=2.22.0
+ricecooker>=0.6.35
+youtube-dl>=2019.9.12.1

--- a/sushichef.py
+++ b/sushichef.py
@@ -11,7 +11,7 @@ from arvind import ArvindVideo, ArvindLanguage
 from bs4 import BeautifulSoup
 
 from ricecooker.chefs import SushiChef
-from ricecooker.classes.files import VideoFile
+from ricecooker.classes.files import YouTubeVideoFile
 from ricecooker.classes.licenses import get_license
 from ricecooker.classes.nodes import VideoNode, TopicNode
 
@@ -75,17 +75,17 @@ def include_video_topic(topic_node, video_data, lang_obj):
     # Include video details to the parent topic node
     video = video_data
     create_id = uuid.uuid4().hex[:12].lower()
-    video_source_id = create_id + str(video.uid) 
+    video_source_id = str(video.uid)
     video_node = VideoNode(
         source_id=video_source_id, 
         title=clean_video_title(video.title, lang_obj), 
         description=video.description,
-        aggregator=LE,
+        author=ARVIND,
         thumbnail=video.thumbnail,
         license=get_license("CC BY-NC", copyright_holder=ARVIND),
         files=[
-            VideoFile(
-                path=video.filepath,
+            YouTubeVideoFile(
+                youtube_id=video.uid,
                 language=video.language
             )
         ])
@@ -118,7 +118,7 @@ def download_video_topics(data, topic, topic_node, lang_obj):
 
             download_path = vinfo['download_path'] + "/" + topic + "/"
 
-            if video.download(download_dir=download_path):
+            if video.download_info(download_dir=download_path):
 
                 if video.license_common:
                     include_video_topic(topic_node, video, lang_obj)

--- a/sushichef.py
+++ b/sushichef.py
@@ -4,9 +4,10 @@ import os
 import pprint
 import requests
 import re
+import shutil
 import uuid
 
-from arvind import ArvindVideo, ArvindLanguage
+from arvind import ArvindVideo, ArvindLanguage, YOUTUBE_CACHE_DIR
 
 from bs4 import BeautifulSoup
 
@@ -309,6 +310,15 @@ class ArvindChef(SushiChef):
                 " Valuable resource library for teachers to incorporate in their lessons, for parents to" \
                 " work with children at home using readily available, simple, and low-cost materials.",
     }
+
+    def pre_run(self, args, options):
+        """This function will get called by ricecooker before the chef runs."""
+        if args['update']:
+            # delete video info .json files cached in chefdata/youtubecache/
+            print('Deleting vinfo .json files in {}'.format(YOUTUBE_CACHE_DIR))
+            if os.path.exists(YOUTUBE_CACHE_DIR):
+                shutil.rmtree(YOUTUBE_CACHE_DIR)
+            os.makedirs(YOUTUBE_CACHE_DIR)
 
     def construct_channel(self, **kwargs):
 

--- a/sushichef.py
+++ b/sushichef.py
@@ -75,7 +75,7 @@ def include_video_topic(topic_node, video_data, lang_obj):
     # Include video details to the parent topic node
     video = video_data
     create_id = uuid.uuid4().hex[:12].lower()
-    video_source_id = str(video.uid)
+    video_source_id = str(video.uid)  # For YouTube imports, set source_id to the youtube_id
     video_node = VideoNode(
         source_id=video_source_id, 
         title=clean_video_title(video.title, lang_obj), 
@@ -138,8 +138,7 @@ def generate_child_topics(arvind_contents, main_topic, lang_obj, topic_type):
     for topic_index in data:
 
         if topic_type == STANDARD_TOPIC:
-            create_id = uuid.uuid4().hex[:12].lower()
-            source_id = create_id + topic_index + lang_obj.code
+            source_id = lang_obj.code + '_' + topic_index
             topic_node = TopicNode(title=topic_index, source_id=source_id)
             download_video_topics(data, topic_index, topic_node, lang_obj)
             main_topic.add_child(topic_node)
@@ -247,8 +246,7 @@ def create_language_topic():
             lang_obj = get_language_details(lang_name.lower())
 
             if lang_obj != None:
-                create_id = uuid.uuid4().hex[:12].lower()
-                language_source_id = create_id + "arvind_main_" + lang_obj.code
+                language_source_id = "arvind_main_" + lang_obj.code
                 lang_name = lang_obj.name
                 lang_name_lower = lang_name.lower()
                 get_language_data = list(arvind_languages[language_next_int])
@@ -277,7 +275,7 @@ def create_language_topic():
 
                         if current_lang != None:
                             topic_type = SINGLE_TOPIC
-                            parent_source_id = create_id + "arvind_main_" + lang.lower()
+                            parent_source_id = "arvind_main_" + lang.lower()
                             parent_topic = TopicNode(title=lang.capitalize(), source_id=parent_source_id)
                             data_dic = {current_lang.name: {"": lang_data[lang]}}
 


### PR DESCRIPTION
   - use YouTubeVideoFile instead of VideoFile  (just need to specify the `youtube_id` and ricecooker will take care of downloading the video, and storing it in `storage/` directly
  - set the youtube_dl  flag to download=False (chef just needs to get the json metadata; the video download happens later)
  - made changes to ensure `content_id = f(source_id)` stay constant between runs --- if `source_id` changes randomly on each chef run this channel cannot be remixed 
  - implemented youtube_dl json data caching. Run the chef with the --update flag to clear youtube json info cache 
